### PR TITLE
Fixes #13 - Use a cordova hook for adding the required attribute 

### DIFF
--- a/hooks/after_prepare/add_to_manifest.js
+++ b/hooks/after_prepare/add_to_manifest.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+// Adds lines to the Android Manifest if they are not already there
+
+const LINES_TO_ADD = [
+    {
+        text: ' android:installLocation="auto"',
+        after: '<manifest'
+    }
+];
+
+const MANIFEST = 'platforms/android/AndroidManifest.xml';
+
+var fs = require('fs'),
+  manifestText = fs.readFileSync(MANIFEST).toString();
+
+LINES_TO_ADD.forEach(function(lineToAdd) {
+  if(manifestText.indexOf(lineToAdd.text) === -1) {
+    manifestText = manifestText.replace(lineToAdd.after, lineToAdd.after + lineToAdd.text);
+  }
+});
+
+fs.writeFileSync(MANIFEST, manifestText);

--- a/hooks/after_prepare/add_to_manifest.js
+++ b/hooks/after_prepare/add_to_manifest.js
@@ -3,16 +3,16 @@
 // Adds lines to the Android Manifest if they are not already there
 
 const LINES_TO_ADD = [
-    {
-        text: ' android:installLocation="auto"',
-        after: '<manifest'
-    }
+  {
+    text: ' android:installLocation="auto"',
+    after: '<manifest'
+  }
 ];
 
 const MANIFEST = 'platforms/android/AndroidManifest.xml';
 
 var fs = require('fs'),
-  manifestText = fs.readFileSync(MANIFEST).toString();
+    manifestText = fs.readFileSync(MANIFEST).toString();
 
 LINES_TO_ADD.forEach(function(lineToAdd) {
   if(manifestText.indexOf(lineToAdd.text) === -1) {


### PR DESCRIPTION
to Android manifest.xml

See 
- http://blog.gearoid.me/?p=58 
- https://cordova.apache.org/docs/en/dev/guide/appdev/hooks/index.html

Tested on Android 5.1-Device
